### PR TITLE
feat: remove inlineflex botao

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -7,7 +7,7 @@
 
         <!-- Email Address -->
         <div>
-            <x-input-label for="email" :value="__('Seu user')" />
+            <x-input-label for="email" :value="__('Email')" />
             <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus autocomplete="username" />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
@@ -26,7 +26,7 @@
 
         <!-- Remember Me -->
         <div class="block mt-4">
-            <label for="remember_me" class="inline-flex items-center">
+            <label for="remember_me" class="items-center">
                 <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" name="remember">
                 <span class="ms-2 text-sm text-gray-600">{{ __('Remember me') }}</span>
             </label>


### PR DESCRIPTION
This pull request includes minor updates to the `login.blade.php` view file to improve clarity and consistency in the user interface.

* **Text Label Update**: Changed the label for the email input field from "Seu user" to "Email" for better clarity and localization. (`resources/views/auth/login.blade.php`)
* **HTML Attribute Adjustment**: Removed the `inline-flex` class from the "Remember Me" label to simplify styling and improve alignment. (`resources/views/auth/login.blade.php`)